### PR TITLE
Fix malformed script/style tags

### DIFF
--- a/pages/EPPS_6302/Home/epps.6302.home.html
+++ b/pages/EPPS_6302/Home/epps.6302.home.html
@@ -490,25 +490,21 @@ ul.task-list li input[type="checkbox"] {
 
 <script src="https://esm.sh/css-doodle/css-doodle.min.js?raw"></script>
 
-
 <style>
   #particles-js {
-  width: 100%;             /* Full width or specify a fixed width */
-  height: 20vh;           /* Fixed height */
-  position: relative;      /* Ensures positioning context */
-  background-color: #F1F2F4;  /* Optional: Set a background color */
-  overflow: hidden;        /* Ensures particles don't overflow */
-}
-
-<style>
-#title-block
+    width: 100%;             /* Full width or specify a fixed width */
+    height: 20vh;            /* Fixed height */
+    position: relative;      /* Ensures positioning context */
+    background-color: #F1F2F4;  /* Optional: Set a background color */
+    overflow: hidden;        /* Ensures particles don't overflow */
+  }
+</style>
 
 <script type="module">
-  import 'https://esm.sh/css-doodle'
-  body { margin: 0; overflow: hidden; }
+  import 'https://esm.sh/css-doodle';
+  document.body.style.margin = 0;
+  document.body.style.overflow = 'hidden';
 </script>
-
-</style></style>
 
 <!-- scripts -->
 <script src="../particles.js"></script>

--- a/pages/EPPS_6323/Home/epps.6323.home.html
+++ b/pages/EPPS_6323/Home/epps.6323.home.html
@@ -495,22 +495,21 @@ ul.task-list li input[type="checkbox"] {
 
 <script src="https://esm.sh/css-doodle/css-doodle.min.js?raw"></script>
 
-
 <style>
   #particles-js {
-  width: 100%;             /* Full width or specify a fixed width */
-  height: 20vh;           /* Fixed height */
-  position: relative;      /* Ensures positioning context */
-  background-color: #F9FAFB;  /* Optional: Set a background color */
-  overflow: hidden;        /* Ensures particles don't overflow */
-}
+    width: 100%;             /* Full width or specify a fixed width */
+    height: 20vh;            /* Fixed height */
+    position: relative;      /* Ensures positioning context */
+    background-color: #F9FAFB;  /* Optional: Set a background color */
+    overflow: hidden;        /* Ensures particles don't overflow */
+  }
+</style>
 
 <script type="module">
-  import 'https://esm.sh/css-doodle'
-  body { margin: 0; overflow: hidden; }
+  import 'https://esm.sh/css-doodle';
+  document.body.style.margin = 0;
+  document.body.style.overflow = 'hidden';
 </script>
-
-</style>
 
 <!-- scripts -->
 <script src="../particles.js"></script>

--- a/pages/EPPS_6354/Home/epps.6354.home.html
+++ b/pages/EPPS_6354/Home/epps.6354.home.html
@@ -494,22 +494,21 @@ ul.task-list li input[type="checkbox"] {
 
 <script src="https://esm.sh/css-doodle/css-doodle.min.js?raw"></script>
 
-
 <style>
   #particles-js {
-  width: 100%;             /* Full width or specify a fixed width */
-  height: 20vh;           /* Fixed height */
-  position: relative;      /* Ensures positioning context */
-  background-color: #F9FAFB;  /* Optional: Set a background color */
-  overflow: hidden;        /* Ensures particles don't overflow */
-}
+    width: 100%;             /* Full width or specify a fixed width */
+    height: 20vh;            /* Fixed height */
+    position: relative;      /* Ensures positioning context */
+    background-color: #F9FAFB;  /* Optional: Set a background color */
+    overflow: hidden;        /* Ensures particles don't overflow */
+  }
+</style>
 
 <script type="module">
-  import 'https://esm.sh/css-doodle'
-  body { margin: 0; overflow: hidden; }
+  import 'https://esm.sh/css-doodle';
+  document.body.style.margin = 0;
+  document.body.style.overflow = 'hidden';
 </script>
-
-</style>
 
 <!-- scripts -->
 <script src="../particles.js"></script>


### PR DESCRIPTION
## Summary
- correct malformed style and script blocks in three course home pages

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684222063000832ba2c56c35ae892dd3