### PR TITLE
Modernize style with assignment index

### DIFF
--- a/About/aboutme.html
+++ b/About/aboutme.html
@@ -75,6 +75,7 @@ ul.task-list li input[type="checkbox"] {
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed fullcontent">

--- a/CopyOfassignment2.html
+++ b/CopyOfassignment2.html
@@ -102,7 +102,8 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 }</script>
 
 
-<link rel="stylesheet" href="styles.css">
+<link rel="stylesheet" href="/styles.css">
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/EPPS6302Final.html
+++ b/EPPS6302Final.html
@@ -69,7 +69,8 @@ ul.task-list li input[type="checkbox"] {
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
 
 
-<link rel="stylesheet" href="styles.css">
+<link rel="stylesheet" href="/styles.css">
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/EPPS6302FinalProjects.html
+++ b/EPPS6302FinalProjects.html
@@ -69,7 +69,8 @@ ul.task-list li input[type="checkbox"] {
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
 
 
-<link rel="stylesheet" href="styles.css">
+<link rel="stylesheet" href="/styles.css">
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/EPPS_6323/Assignment01/EPPS_6323_Assignment01.html
+++ b/EPPS_6323/Assignment01/EPPS_6323_Assignment01.html
@@ -75,6 +75,7 @@ ul.task-list li input[type="checkbox"] {
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/EPPS_6323/Assignment01/Lab01.html
+++ b/EPPS_6323/Assignment01/Lab01.html
@@ -104,6 +104,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 }</script>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/EPPS_6323/Assignment01/Lab02.html
+++ b/EPPS_6323/Assignment01/Lab02.html
@@ -104,6 +104,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 }</script>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/EPPS_6323/Assignment02/EPPS_6323_Assignment02.html
+++ b/EPPS_6323/Assignment02/EPPS_6323_Assignment02.html
@@ -109,6 +109,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/EPPS_6323/Assignment02/Lab01.html
+++ b/EPPS_6323/Assignment02/Lab01.html
@@ -104,6 +104,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 }</script>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/EPPS_6323/Assignment02/Lab02.html
+++ b/EPPS_6323/Assignment02/Lab02.html
@@ -104,6 +104,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 }</script>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/EPPS_6323/Assignment03/EPPS_6323_Assignment03.html
+++ b/EPPS_6323/Assignment03/EPPS_6323_Assignment03.html
@@ -75,6 +75,7 @@ ul.task-list li input[type="checkbox"] {
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/EPPS_6323/Assignment03/Untitled.html
+++ b/EPPS_6323/Assignment03/Untitled.html
@@ -69,6 +69,7 @@ ul.task-list li input[type="checkbox"] {
 }</script>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/EPPS_6323/Assignment04/EPPS_6323_Assignment04.html
+++ b/EPPS_6323/Assignment04/EPPS_6323_Assignment04.html
@@ -109,6 +109,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/EPPS_6323/Assignment05/nlp_assignment05.html
+++ b/EPPS_6323/Assignment05/nlp_assignment05.html
@@ -109,6 +109,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/EPPS_6323/Home/epps.6323.home.html
+++ b/EPPS_6323/Home/epps.6323.home.html
@@ -75,6 +75,7 @@ ul.task-list li input[type="checkbox"] {
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/EPPS_6323/Prepare07/EPPS_6323_prepare07.html
+++ b/EPPS_6323/Prepare07/EPPS_6323_prepare07.html
@@ -75,6 +75,7 @@ ul.task-list li input[type="checkbox"] {
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/EPPS_6323/projectproposal/EPPS_6323_projectproposal.html
+++ b/EPPS_6323/projectproposal/EPPS_6323_projectproposal.html
@@ -75,6 +75,7 @@ ul.task-list li input[type="checkbox"] {
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/Lab01.html
+++ b/Lab01.html
@@ -71,7 +71,8 @@ ul.task-list li input[type="checkbox"] {
 <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
 
 
-<link rel="stylesheet" href="styles.css">
+<link rel="stylesheet" href="/styles.css">
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/Lab02.html
+++ b/Lab02.html
@@ -71,7 +71,8 @@ ul.task-list li input[type="checkbox"] {
 <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
 
 
-<link rel="stylesheet" href="styles.css">
+<link rel="stylesheet" href="/styles.css">
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/Particle.Test.html
+++ b/Particle.Test.html
@@ -73,6 +73,7 @@ ul.task-list li input[type="checkbox"] {
 }</script>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/about.html
+++ b/about.html
@@ -102,7 +102,8 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 }</script>
 
 
-<link rel="stylesheet" href="styles.css">
+<link rel="stylesheet" href="/styles.css">
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/aboutme.html
+++ b/aboutme.html
@@ -71,6 +71,7 @@ ul.task-list li input[type="checkbox"] {
 }</script>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/assignment2.html
+++ b/assignment2.html
@@ -104,7 +104,8 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
 
 
-<link rel="stylesheet" href="styles.css">
+<link rel="stylesheet" href="/styles.css">
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/assignment3.html
+++ b/assignment3.html
@@ -104,7 +104,8 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
 
 
-<link rel="stylesheet" href="styles.css">
+<link rel="stylesheet" href="/styles.css">
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/assignment4.html
+++ b/assignment4.html
@@ -104,7 +104,8 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
 
 
-<link rel="stylesheet" href="styles.css">
+<link rel="stylesheet" href="/styles.css">
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/assignment5.html
+++ b/assignment5.html
@@ -104,7 +104,8 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
 
 
-<link rel="stylesheet" href="styles.css">
+<link rel="stylesheet" href="/styles.css">
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/assignments.html
+++ b/assignments.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Assignments | Oliver Myers</title>
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+<header class="navbar navbar-expand-sm">
+  <div class="container">
+    <a class="navbar-brand" href="/index.html">Oliver Myers</a>
+  </div>
+</header>
+<main class="container">
+  <h1>Assignments</h1>
+
+  <section>
+    <h2>EPPS 6302 - Data Collection &amp; Production</h2>
+    <div class="assignment-grid">
+      <div class="assignment-card"><a href="/pages/EPPS_6302/FinalProject/final_project.html">Final Project</a></div>
+      <div class="assignment-card"><a href="/pages/EPPS_6302/Assignment01/assignment2.html">Assignment 1</a></div>
+      <div class="assignment-card"><a href="/pages/EPPS_6302/Assignment02/assignment3.html">Assignment 2</a></div>
+      <div class="assignment-card"><a href="/pages/EPPS_6302/Assignment03/assignment4.html">Assignment 3</a></div>
+      <div class="assignment-card"><a href="/pages/EPPS_6302/Assignment04/assignment5.html">Assignment 4</a></div>
+    </div>
+  </section>
+
+  <section>
+    <h2>EPPS 6323 - Knowledge Mining</h2>
+    <div class="assignment-grid">
+      <div class="assignment-card"><a href="/pages/EPPS_6323/projectproposal/EPPS_6323_projectproposal.html">Final Project</a></div>
+      <div class="assignment-card"><a href="/pages/EPPS_6323/Assignment01/EPPS_6323_Assignment01.html">Assignment 1</a></div>
+      <div class="assignment-card"><a href="/pages/EPPS_6323/Assignment02/EPPS_6323_Assignment02.html">Assignment 2</a></div>
+      <div class="assignment-card"><a href="/pages/EPPS_6323/Assignment03/EPPS_6323_Assignment03.html">Assignment 3</a></div>
+      <div class="assignment-card"><a href="/pages/EPPS_6323/Assignment04/EPPS_6323_Assignment04.html">Assignment 4</a></div>
+      <div class="assignment-card"><a href="/pages/EPPS_6323/Assignment05/nlp_assignment05.html">Assignment 5</a></div>
+    </div>
+  </section>
+
+  <section>
+    <h2>EPPS 6354 - Information Management</h2>
+    <div class="assignment-grid">
+      <div class="assignment-card"><a href="/pages/EPPS_6354/projectproposal/EPPS_6354_projectproposal.html">Final Project</a></div>
+      <div class="assignment-card"><a href="/pages/EPPS_6354/Assignment01/epps.6354.assignment1.html">Assignment 1</a></div>
+      <div class="assignment-card"><a href="/pages/EPPS_6354/Assignment02/epps.6354.assignment2.html">Assignment 2</a></div>
+      <div class="assignment-card"><a href="/pages/EPPS_6354/Assignment03/epps.6354.assignment3.html">Assignment 3</a></div>
+      <div class="assignment-card"><a href="/pages/EPPS_6354/Assignment04/EPPS_6354_Assignment04.html">Assignment 4</a></div>
+      <div class="assignment-card"><a href="/pages/EPPS_6354/Assignment05/epps.6354.assignment5.html">Assignment 5</a></div>
+      <div class="assignment-card"><a href="/pages/EPPS_6354/Assignment06/epps.6354.assignment06.html">Assignment 6</a></div>
+      <div class="assignment-card"><a href="/pages/EPPS_6354/Assignment07/epps.6354.assignment07.html">Assignment 7</a></div>
+    </div>
+  </section>
+
+</main>
+</body>
+</html>

--- a/epps.6302.assignment1.html
+++ b/epps.6302.assignment1.html
@@ -70,7 +70,8 @@ ul.task-list li input[type="checkbox"] {
 <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
 
 
-<link rel="stylesheet" href="styles.css">
+<link rel="stylesheet" href="/styles.css">
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/epps.6302.home.html
+++ b/epps.6302.home.html
@@ -109,6 +109,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <script src="site_libs/particles-binding-0.1.1/particles.js"></script>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/epps.6354.home.html
+++ b/epps.6354.home.html
@@ -70,7 +70,8 @@ ul.task-list li input[type="checkbox"] {
 <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
 
 
-<link rel="stylesheet" href="styles.css">
+<link rel="stylesheet" href="/styles.css">
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/epps6354_assignment4.html
+++ b/epps6354_assignment4.html
@@ -70,7 +70,8 @@ ul.task-list li input[type="checkbox"] {
 <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
 
 
-<link rel="stylesheet" href="styles.css">
+<link rel="stylesheet" href="/styles.css">
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/finalProject.html
+++ b/finalProject.html
@@ -103,7 +103,8 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
 
 
-<link rel="stylesheet" href="styles.css">
+<link rel="stylesheet" href="/styles.css">
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/final_project.html
+++ b/final_project.html
@@ -70,7 +70,8 @@ ul.task-list li input[type="checkbox"] {
 <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
 
 
-<link rel="stylesheet" href="styles.css">
+<link rel="stylesheet" href="/styles.css">
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/index.html
+++ b/index.html
@@ -72,8 +72,8 @@ ul.task-list li input[type="checkbox"] {
       .quarto-title-block .quarto-title-banner {
         background: #E2F2FF;
       }
-</style>
-
+  </style>
+  <link rel="stylesheet" href="/styles.css">
 
 </head>
 
@@ -211,6 +211,7 @@ ul.task-list li input[type="checkbox"] {
     <a class="nav-link" href="./pages/cv/oliver.myers.uxr.cv.2024.pdf"> 
 <span class="menu-text">CV</span></a>
   </li>  
+  <li class="nav-item"><a class="nav-link" href="/assignments.html"><span class="menu-text">Assignments</span></a></li>
   <li class="nav-item">
     <a class="nav-link" href="./pages/About/aboutme.html"> 
 <span class="menu-text">About</span></a>

--- a/nlp_assignment05.html
+++ b/nlp_assignment05.html
@@ -103,6 +103,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 }</script>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/pages/About/aboutme.html
+++ b/pages/About/aboutme.html
@@ -75,6 +75,7 @@ ul.task-list li input[type="checkbox"] {
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed fullcontent">

--- a/pages/EPPS_6302/Assignment01/assignment2.html
+++ b/pages/EPPS_6302/Assignment01/assignment2.html
@@ -109,6 +109,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/pages/EPPS_6302/Assignment02/assignment3.html
+++ b/pages/EPPS_6302/Assignment02/assignment3.html
@@ -109,6 +109,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/pages/EPPS_6302/Assignment03/assignment4.html
+++ b/pages/EPPS_6302/Assignment03/assignment4.html
@@ -109,6 +109,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/pages/EPPS_6302/Assignment04/assignment5.html
+++ b/pages/EPPS_6302/Assignment04/assignment5.html
@@ -109,6 +109,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/pages/EPPS_6302/FinalProject/EPPS6302FinalProjects.html
+++ b/pages/EPPS_6302/FinalProject/EPPS6302FinalProjects.html
@@ -69,6 +69,7 @@ ul.task-list li input[type="checkbox"] {
 }</script>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/pages/EPPS_6302/FinalProject/final_project.html
+++ b/pages/EPPS_6302/FinalProject/final_project.html
@@ -75,6 +75,7 @@ ul.task-list li input[type="checkbox"] {
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/pages/EPPS_6302/Home/epps.6302.home.html
+++ b/pages/EPPS_6302/Home/epps.6302.home.html
@@ -75,6 +75,7 @@ ul.task-list li input[type="checkbox"] {
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/pages/EPPS_6323/Assignment01/EPPS_6323_Assignment01.html
+++ b/pages/EPPS_6323/Assignment01/EPPS_6323_Assignment01.html
@@ -75,6 +75,7 @@ ul.task-list li input[type="checkbox"] {
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/pages/EPPS_6323/Assignment01/Lab01.html
+++ b/pages/EPPS_6323/Assignment01/Lab01.html
@@ -104,6 +104,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 }</script>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/pages/EPPS_6323/Assignment01/Lab02.html
+++ b/pages/EPPS_6323/Assignment01/Lab02.html
@@ -104,6 +104,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 }</script>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/pages/EPPS_6323/Assignment02/EPPS_6323_Assignment02.html
+++ b/pages/EPPS_6323/Assignment02/EPPS_6323_Assignment02.html
@@ -109,6 +109,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/pages/EPPS_6323/Assignment02/Lab01.html
+++ b/pages/EPPS_6323/Assignment02/Lab01.html
@@ -104,6 +104,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 }</script>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/pages/EPPS_6323/Assignment02/Lab02.html
+++ b/pages/EPPS_6323/Assignment02/Lab02.html
@@ -104,6 +104,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 }</script>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/pages/EPPS_6323/Assignment03/EPPS_6323_Assignment03.html
+++ b/pages/EPPS_6323/Assignment03/EPPS_6323_Assignment03.html
@@ -75,6 +75,7 @@ ul.task-list li input[type="checkbox"] {
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/pages/EPPS_6323/Assignment03/Untitled.html
+++ b/pages/EPPS_6323/Assignment03/Untitled.html
@@ -69,6 +69,7 @@ ul.task-list li input[type="checkbox"] {
 }</script>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/pages/EPPS_6323/Assignment04/EPPS_6323_Assignment04.html
+++ b/pages/EPPS_6323/Assignment04/EPPS_6323_Assignment04.html
@@ -109,6 +109,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/pages/EPPS_6323/Assignment05/nlp_assignment05.html
+++ b/pages/EPPS_6323/Assignment05/nlp_assignment05.html
@@ -109,6 +109,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/pages/EPPS_6323/EPPS_6323_projectproposal.html
+++ b/pages/EPPS_6323/EPPS_6323_projectproposal.html
@@ -75,6 +75,7 @@ ul.task-list li input[type="checkbox"] {
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/pages/EPPS_6323/Home/epps.6323.home.html
+++ b/pages/EPPS_6323/Home/epps.6323.home.html
@@ -75,6 +75,7 @@ ul.task-list li input[type="checkbox"] {
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/pages/EPPS_6323/Prepare07/EPPS_6323_prepare07.html
+++ b/pages/EPPS_6323/Prepare07/EPPS_6323_prepare07.html
@@ -75,6 +75,7 @@ ul.task-list li input[type="checkbox"] {
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/pages/EPPS_6323/projectproposal/EPPS_6323_projectproposal.html
+++ b/pages/EPPS_6323/projectproposal/EPPS_6323_projectproposal.html
@@ -75,6 +75,7 @@ ul.task-list li input[type="checkbox"] {
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/pages/EPPS_6354/Assignment01/epps.6354.assignment1.html
+++ b/pages/EPPS_6354/Assignment01/epps.6354.assignment1.html
@@ -75,6 +75,7 @@ ul.task-list li input[type="checkbox"] {
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/pages/EPPS_6354/Assignment02/epps.6354.assignment2.html
+++ b/pages/EPPS_6354/Assignment02/epps.6354.assignment2.html
@@ -75,6 +75,7 @@ ul.task-list li input[type="checkbox"] {
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/pages/EPPS_6354/Assignment03/epps.6354.assignment3.html
+++ b/pages/EPPS_6354/Assignment03/epps.6354.assignment3.html
@@ -75,6 +75,7 @@ ul.task-list li input[type="checkbox"] {
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/pages/EPPS_6354/Assignment04/EPPS_6354_Assignment04.html
+++ b/pages/EPPS_6354/Assignment04/EPPS_6354_Assignment04.html
@@ -75,6 +75,7 @@ ul.task-list li input[type="checkbox"] {
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/pages/EPPS_6354/Assignment04/epps6354_assignment4.html
+++ b/pages/EPPS_6354/Assignment04/epps6354_assignment4.html
@@ -69,6 +69,7 @@ ul.task-list li input[type="checkbox"] {
 }</script>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/pages/EPPS_6354/Assignment05/epps.6354.assignment5.html
+++ b/pages/EPPS_6354/Assignment05/epps.6354.assignment5.html
@@ -75,6 +75,7 @@ ul.task-list li input[type="checkbox"] {
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/pages/EPPS_6354/Assignment06/epps.6354.assignment06.html
+++ b/pages/EPPS_6354/Assignment06/epps.6354.assignment06.html
@@ -75,6 +75,7 @@ ul.task-list li input[type="checkbox"] {
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/pages/EPPS_6354/Assignment06/epps.6354.assignment5.html
+++ b/pages/EPPS_6354/Assignment06/epps.6354.assignment5.html
@@ -75,6 +75,7 @@ ul.task-list li input[type="checkbox"] {
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/pages/EPPS_6354/Assignment07/epps.6354.assignment07.html
+++ b/pages/EPPS_6354/Assignment07/epps.6354.assignment07.html
@@ -75,6 +75,7 @@ ul.task-list li input[type="checkbox"] {
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed fullcontent">

--- a/pages/EPPS_6354/Home/epps.6354.home.html
+++ b/pages/EPPS_6354/Home/epps.6354.home.html
@@ -75,6 +75,7 @@ ul.task-list li input[type="checkbox"] {
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/pages/EPPS_6354/projectproposal/EPPS_6354_projectproposal.html
+++ b/pages/EPPS_6354/projectproposal/EPPS_6354_projectproposal.html
@@ -75,6 +75,7 @@ ul.task-list li input[type="checkbox"] {
 </style>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/particle-js/Particle.Test.html
+++ b/particle-js/Particle.Test.html
@@ -73,6 +73,7 @@ ul.task-list li input[type="checkbox"] {
 }</script>
 
 
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/personal.html
+++ b/personal.html
@@ -68,7 +68,8 @@ ul.task-list li input[type="checkbox"] {
 }</script>
 
 
-<link rel="stylesheet" href="styles.css">
+<link rel="stylesheet" href="/styles.css">
+  <link rel="stylesheet" href="/styles.css">
 </head>
 
 <body class="nav-fixed">

--- a/styles.css
+++ b/styles.css
@@ -1,32 +1,32 @@
-/* css styles 
-
-.hover-links a:hover {
-    color: black;
+/* css styles */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
+:root {
+  --brand-color: #0d6efd;
+  --bg-color: #f7f9fc;
+  --text-color: #333;
+  --card-bg: #fff;
+  --card-border: #e0e0e0;
 }
 
- h2, .h2, h3, .h3 {
-    margin-top: 36px;
-    webkit-text-fill-color: #1F2328;
-    color:#1F2328;
+h1, h2, h3, h4, h5, h6 {
+  color: var(--brand-color);
+  font-weight: 700;
+  margin-top: 1.5rem;
+  margin-bottom: .5rem;
 }
 
-h1, .h1 {
-    margin-top: 40px;
-    margin-bottom: 40px;
-    webkit-text-fill-color: #1F2328;
-    color:#1F2328;
-}
-
-*/
 
 
 /* ---- reset ---- */
 
 body {
   margin: 0;
-  font:normal 75% Arial, Helvetica, sans-serif;
+  font-family: 'Inter', Arial, Helvetica, sans-serif;
+  line-height: 1.6;
+  background: var(--bg-color);
+  color: var(--text-color);
+  font-size: 16px;
 }
-
 canvas {
   display: block;
   vertical-align: bottom;
@@ -59,7 +59,7 @@ canvas {
   text-indent: 4px;
   line-height: 14px;
   padding-bottom: 2px;
-  font-family: Helvetica, Arial, sans-serif;
+  font-family: 'Inter', Helvetica, Arial, sans-serif;
   font-weight: bold;
 }
 
@@ -79,4 +79,38 @@ canvas {
 
 .count-particles{
   border-radius: 0 0 3px 3px;
+}
+.navbar {
+  background: var(--brand-color) !important;
+}
+.navbar-brand, .navbar-nav .nav-link {
+  color: #fff !important;
+}
+.navbar-brand:hover, .navbar-nav .nav-link:hover {
+  color: #e2e6ea !important;
+}
+
+.assignment-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+.assignment-card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 8px;
+  padding: 1rem;
+  text-align: center;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  width: 280px;
+}
+.assignment-card img {
+  max-width: 100%;
+  border-radius: 4px;
+}
+.assignment-card a {
+  text-decoration: none;
+  color: var(--brand-color);
+  font-weight: 700;
 }


### PR DESCRIPTION
## Summary
- add site-wide Inter font and color variables
- update body styles and new navbar/card classes
- add global assignments.html page summarizing coursework
- link to new page from the homepage navigation
- reference stylesheet from all pages

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68422e40c7dc832b83d1429700f09030